### PR TITLE
Update to non-deprecated CI image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ jobs:
     parallelism: 1
     working_directory: ~/change/babel-plugin-cjs-modular-lodash
     docker:
-      - image: circleci/node:10.15.3
+      - image: cimg/node:10.15.3
     steps:
       - checkout
       - restore_cache:


### PR DESCRIPTION
https://circleci.com/docs/2.0/next-gen-migration-guide/